### PR TITLE
Start parsing text objects and implement 'dw' command.

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -305,6 +305,10 @@ func (b *Buffer) Delete(c Cursor, numBytes int) {
 	b.History.Append(a)
 }
 
+func (b *Buffer) DeleteRange(from Cursor, to Cursor) {
+	b.Delete(from, from.Distance(to))
+}
+
 func (b *Buffer) Undo() {
 	if b.History.Prev == nil {
 		// we're at the sentinel, no more things to undo

--- a/buffer/cursor.go
+++ b/buffer/cursor.go
@@ -7,6 +7,8 @@ import (
 	"unicode/utf8"
 )
 
+type RangeFunc func(from Cursor, to Cursor)
+
 type Cursor struct {
 	Line    *Line
 	LineNum int

--- a/editor/normal.go
+++ b/editor/normal.go
@@ -81,6 +81,11 @@ func (m *normalMode) onKey(ev *termbox.Event) {
 		v.onVcommand(viewCommand{Cmd: vCommandMoveCursorEndOfLine})
 	}
 
+	switch ev.Ch {
+	case 'd':
+		g.setMode(newTextObjectMode(g, m, v.buf.DeleteRange, reps))
+	}
+
 	if ev.Ch == 0x0 {
 		switch ev.Key {
 		// TODO Cursor centering after Ctrl-U/D seems off.

--- a/editor/textobject.go
+++ b/editor/textobject.go
@@ -1,13 +1,36 @@
 package editor
 
 import (
+	"errors"
+	"fmt"
+	"github.com/kisielk/vigo/buffer"
 	"github.com/nsf/termbox-go"
 )
 
 type textObjectMode struct {
 	editor *editor
+	mode   editorMode
 	object textObject
+	stage  textObjectStage // Text object parsing stage
+	err    error           // Set in case of error during text object parsing.
+
+	// Buffer modifier operating on range of cursors; set
+	// to run after text object input is complete.
+	f buffer.RangeFunc
+
+	outerReps int    // Outer repetitions preceding the initial command.
+	repChars  []rune // Temporary buffer for inner repetition digits.
+	reps      int    // Inner repetitions
 }
+
+type textObjectStage int
+
+// Text object parsing stages
+const (
+	textObjectStageReps textObjectStage = iota
+	textObjectStageChar1
+	textObjectStageChar2
+)
 
 type textObject struct {
 	inner bool
@@ -27,31 +50,83 @@ const (
 	textObjectBraces
 )
 
-func newTextObjectMode(editor *editor, inner bool) *textObjectMode {
-	return &textObjectMode{editor: editor, object: textObject{inner: inner}}
+var textObjectKeyToType = map[rune]textObjectKind{
+	'w': textObjectWord,
+	'W': textObjectWhitespaceWord,
+	's': textObjectSentence,
+	'p': textObjectParagraph,
+	'S': textObjectSection,
+	'%': textObjectPercent,
+	'b': textObjectParens,
+	'B': textObjectBraces,
 }
 
-func (m *textObjectMode) onKey(ev *termbox.Event) {
-	switch ev.Ch {
-	case 'w':
-		m.object.kind = textObjectWord
-	case 'W':
-		m.object.kind = textObjectWhitespaceWord
-	case 's':
-		m.object.kind = textObjectSentence
-	case 'p':
-		m.object.kind = textObjectParagraph
-	case 'S':
-		m.object.kind = textObjectSection
-	case '%':
-		m.object.kind = textObjectPercent
-	case 'b':
-		m.object.kind = textObjectParens
-	case 'B':
-		m.object.kind = textObjectBraces
+func newTextObjectMode(editor *editor, mode editorMode, f buffer.RangeFunc, reps int) *textObjectMode {
+	return &textObjectMode{
+		editor:    editor,
+		mode:      mode,
+		object:    textObject{},
+		stage:     textObjectStageReps,
+		f:         f,
+		outerReps: reps,
 	}
 }
 
-func (m *textObjectMode) OnExit() {
-	//TODO: Return the text object to the previous mode somehow
+var ErrBadTextObject error = errors.New("bad text object")
+
+func (m *textObjectMode) onKey(ev *termbox.Event) {
+loop:
+	switch m.stage {
+	case textObjectStageReps:
+		if ('0' < ev.Ch && ev.Ch <= '9') || (ev.Ch == '0' && len(m.repChars) > 0) {
+			m.repChars = append(m.repChars, ev.Ch)
+		} else {
+			m.reps = parseReps(string(m.repChars))
+			m.stage = textObjectStageChar1
+			goto loop
+		}
+	case textObjectStageChar1:
+		switch ev.Ch {
+		case 'i':
+			m.object.inner = true
+		case 'a':
+			m.object.inner = false
+		default:
+			m.stage = textObjectStageChar2
+			goto loop
+		}
+	case textObjectStageChar2:
+		if kind, ok := textObjectKeyToType[ev.Ch]; ok {
+			m.object.kind = kind
+		} else {
+			m.err = ErrBadTextObject
+		}
+		m.editor.setMode(m.mode)
+	}
+}
+
+func (m *textObjectMode) exit() {
+	if m.err != nil {
+		// TODO simpler way to get error string?
+		m.editor.setStatus(fmt.Sprintf("%v", m.err))
+		return
+	}
+
+	v := m.editor.active.leaf
+
+	switch m.object.kind {
+	case textObjectWord:
+		for i := 0; i < m.reps*m.outerReps; i++ {
+			from := v.cursor
+			to := v.cursor
+			// FIXME this wraps onto next line
+			if !to.NextWord() {
+				v.ctx.setStatus("End of buffer")
+			}
+			m.f(from, to)
+		}
+		v.buf.FinalizeActionGroup()
+	default:
+		m.editor.setStatus("range conversion not implemented")
+	}
 }


### PR DESCRIPTION
CC @kisielk 

Looking for initial feedback on the general direction.

Follow the same model as 'i'/'a', where we use onExit() to perform intended
action (in this case, transforming text object to cursor range and running
specified modifier function)

Discussion points
- Is this the right place for text object / cursor range conversion. Will this work for all cases? There's a question of how to implement stuff like '.' command, where we definitely need to remember last text object rather than pair of cursors. However, I think text object mode can set something like 'editor.lastTextObject' inside onExit() 
- Should the incremental key combo parser be factored out and generalized? Could probably be used in other spots as well.
- view.onVcommand has some pre/post logic such as finalizing history and performing repetitions. Either we do it manually every time or onVcommand persists in some shape or form (but definitely under different name)
