### PR TITLE
Add change and delete to end of line commands

### DIFF
--- a/editor/normal.go
+++ b/editor/normal.go
@@ -124,11 +124,10 @@ func (m *normalMode) onKey(ev *termbox.Event) {
 		// TODO: Distinction from 'b'
 		v.onVcommand(viewCommand{Cmd: vCommandMoveCursorWordBackward, Count: count})
 	case 'C':
-		// TODO: Change text to end of line
-		return
+		v.onVcommand(viewCommand{Cmd: vCommandDeleteToEndOfLine})
+		g.setMode(newInsertMode(g, count))
 	case 'D':
-		// TODO: Delete till end of line
-		return
+		v.onVcommand(viewCommand{Cmd: vCommandDeleteToEndOfLine})
 	case 'E':
 		// TODO: Distinction from 'e'
 		v.onVcommand(viewCommand{Cmd: vCommandMoveCursorWordEnd, Count: count})

--- a/editor/view.go
+++ b/editor/view.go
@@ -986,6 +986,8 @@ func (v *view) onVcommand(c viewCommand) {
 			})
 		case vCommandWordToLower:
 			v.wordTo(bytes.ToLower)
+		case vCommandDeleteToEndOfLine:
+			v.deleteToEndOfLine();
 		}
 	}
 
@@ -1143,6 +1145,14 @@ func (v *view) filterText(from, to buffer.Cursor, filter func([]byte) []byte) {
 	v.buf.Insert(c1, data)
 }
 
+// Delete from the current cursor position to the end of the line.
+func (v *view) deleteToEndOfLine() {
+	c := v.cursor
+	l := c.Line
+	d := l.Data[:c.Boffset]
+	v.buf.Delete(c, len(l.Data) - len(d) )
+}
+
 //----------------------------------------------------------------------------
 // view commands
 //----------------------------------------------------------------------------
@@ -1206,6 +1216,7 @@ const (
 	vCommandKillWord
 	vCommandKillWordBackward
 	vCommandKillRegion
+	vCommandDeleteToEndOfLine	
 	_vCommandDeletionEnd
 
 	// history commands (undo/redo)


### PR DESCRIPTION
Added "Change to end of line" and "Delete to end of line" to normal mode.

Both commands use the same function, the difference being that "change" also changes the editor mode to Insert.
