### PR TITLE
Add move to line command

### DIFF
--- a/editor/command.go
+++ b/editor/command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"strconv"
 
 	"github.com/nsf/termbox-go"
 )
@@ -95,5 +96,12 @@ func execCommand(e *Editor, command string) error {
 		}
 		e.active.leaf.attach(buffer)
 	}
+
+	if lineNum, err := strconv.Atoi(cmd); err == nil {
+		// cmd is a number, we should move to that line
+		v := e.active.leaf
+		v.MoveCursorToLine(lineNum)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Added ability to navigate to a given line by entering a number in command mode.

For instance: `:21` will bring you to line 21 or the current file.
