### PR TITLE
Added initial search functionality

### DIFF
--- a/buffer/cursor.go
+++ b/buffer/cursor.go
@@ -435,39 +435,6 @@ func (c *Cursor) OnDeleteAdjust(a *Action) {
 	c.Boffset = a.Cursor.Boffset + n
 }
 
-func (c Cursor) searchForward(word []byte) (Cursor, bool) {
-	for c.Line != nil {
-		i := bytes.Index(c.Line.Data[c.Boffset:], word)
-		if i != -1 {
-			c.Boffset += i
-			return c, true
-		}
-
-		c.Line = c.Line.Next
-		c.LineNum++
-		c.Boffset = 0
-	}
-	return c, false
-}
-
-func (c Cursor) searchBackward(word []byte) (Cursor, bool) {
-	for {
-		i := bytes.LastIndex(c.Line.Data[:c.Boffset], word)
-		if i != -1 {
-			c.Boffset = i
-			return c, true
-		}
-
-		c.Line = c.Line.Prev
-		if c.Line == nil {
-			break
-		}
-		c.LineNum--
-		c.Boffset = len(c.Line.Data)
-	}
-	return c, false
-}
-
 // SortCursors orders a pair of cursors, from closest to
 // furthest from the beginning of the buffer.
 func SortCursors(c1, c2 Cursor) (r1, r2 Cursor) {

--- a/commands/search.go
+++ b/commands/search.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"bytes"
+	"github.com/kisielk/vigo/editor"
+)
+
+type Search struct {
+	Dir  Dir
+}
+
+func (s Search) Apply(e *editor.Editor) {
+	v := e.ActiveView()
+	c := v.Cursor()
+
+	word := []byte(e.LastSearchTerm)
+
+	switch s.Dir {
+	case Forward:
+		e.SetStatus("Search forward for: %s", e.LastSearchTerm)
+		for c.Line != nil {
+
+			// move the cursor one run forward.
+			// this allows us to move to the next match.
+			// without this, if the word under the cursor is a match,
+			// then we won't be able to advance to the next match
+			c.NextRune(false)
+
+			i := bytes.Index(c.Line.Data[c.Boffset:], word)
+			if i != -1 {
+				c.Boffset += i
+				break
+			}
+
+			c.Line = c.Line.Next
+			if c.Line == nil {
+				e.SetStatus("No more results")
+				return
+			}
+
+			c.LineNum++
+			c.Boffset = 0
+		}
+	case Backward:
+		e.SetStatus("Search backward for: %s", e.LastSearchTerm)
+		for {
+			i := bytes.LastIndex(c.Line.Data[:c.Boffset], word)
+
+			if i != -1 {
+				c.Boffset = i
+				break
+			}
+
+			c.Line = c.Line.Prev
+			if c.Line == nil {
+				e.SetStatus("No previous results")
+				return
+			}
+			c.LineNum--
+			c.Boffset = len(c.Line.Data)
+		}
+	}
+
+	v.MoveCursorTo(c)
+}
+
+
+func searchForward(e *editor.Editor) {
+	
+}

--- a/commands/search.go
+++ b/commands/search.go
@@ -22,7 +22,7 @@ func (s Search) Apply(e *editor.Editor) {
 	switch s.Dir {
 	case Forward:
 		e.SetStatus("Search forward for: %s", e.LastSearchTerm)
-		for c.Line != nil {
+		for {
 
 			// move the cursor one run forward.
 			// this allows us to move to the next match.

--- a/commands/search.go
+++ b/commands/search.go
@@ -67,8 +67,3 @@ func (s Search) Apply(e *editor.Editor) {
 
 	v.MoveCursorTo(c)
 }
-
-
-func searchForward(e *editor.Editor) {
-	
-}

--- a/commands/search.go
+++ b/commands/search.go
@@ -13,6 +13,10 @@ func (s Search) Apply(e *editor.Editor) {
 	v := e.ActiveView()
 	c := v.Cursor()
 
+	if e.LastSearchTerm == "" {
+		e.SetStatus("Nothing to search for.")
+		return
+	}
 	word := []byte(e.LastSearchTerm)
 
 	switch s.Dir {

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -59,6 +59,8 @@ type Editor struct {
 	quitFlag    bool
 	killBuffer_ []byte
 
+	LastSearchTerm string
+
 	// Event channels
 	UIEvents chan termbox.Event
 	Commands chan Command

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -141,8 +141,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		// TODO: Move to line in the middle of the screen
 		return
 	case 'N':
-		// TODO: Repeat previous search, backwards
-		return
+		g.Commands <- cmd.Search{Dir: cmd.Backward}
 	case 'O':
 		g.Commands <- cmd.Repeat{cmd.NewLine{Dir: cmd.Backward}, count}
 		g.SetMode(NewInsertMode(g, count))
@@ -197,6 +196,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		g.Commands <- cmd.Repeat{cmd.DeleteRune{}, count}
 	case 'u':
 		g.Commands <- cmd.Repeat{cmd.Undo{}, count}
+	case 'n':
+		g.Commands <- cmd.Search{Dir: cmd.Forward}
 	}
 
 	switch ev.Ch {
@@ -210,6 +211,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	case ':':
 		// TODO use count to set range for command mode
 		g.SetMode(NewCommandMode(g, m))
+	case '/':
+		g.SetMode(NewSearchMode(g, m))
 	}
 
 	// Reset repetitions

--- a/mode/search.go
+++ b/mode/search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kisielk/vigo/editor"
+	cmd "github.com/kisielk/vigo/commands"
 	"github.com/nsf/termbox-go"
 )
 
@@ -46,6 +47,7 @@ func (m SearchMode) OnKey(ev *termbox.Event) {
 		} else {
 			m.editor.SetStatus("/" + c)
 		}
+		m.editor.Commands <- cmd.Search{Dir: cmd.Forward}
 		m.editor.SetMode(m.mode)
 	case termbox.KeySpace:
 		m.buffer.WriteRune(' ')

--- a/mode/search.go
+++ b/mode/search.go
@@ -1,0 +1,72 @@
+package mode
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/kisielk/vigo/editor"
+	"github.com/nsf/termbox-go"
+)
+
+type SearchMode struct {
+	editor.Overlay
+	editor *editor.Editor
+	mode   editor.Mode
+	buffer *bytes.Buffer
+}
+
+func NewSearchMode(editor *editor.Editor, mode editor.Mode) SearchMode {
+	m := SearchMode{editor: editor, mode: mode, buffer: &bytes.Buffer{}}
+	return m
+}
+
+func (m SearchMode) NeedsCursor() bool {
+	return true
+}
+
+func (m SearchMode) CursorPosition() (int, int) {
+	e := m.editor
+	return m.buffer.Len() + 1, e.Height() - 1
+}
+
+func (m SearchMode) OnKey(ev *termbox.Event) {
+	switch ev.Key {
+	case termbox.KeyEsc, termbox.KeyCtrlC:
+		m.editor.SetMode(m.mode)
+	case termbox.KeyBackspace, termbox.KeyBackspace2:
+		l := m.buffer.Len()
+		if l > 0 {
+			m.buffer.Truncate(l - 1)
+		}
+	case termbox.KeyEnter:
+		c := m.buffer.String()
+		if err := storeSearchTerm(m.editor, c); err != nil {
+			m.editor.SetStatus(fmt.Sprintf("error: %s", err))
+		} else {
+			m.editor.SetStatus("/" + c)
+		}
+		m.editor.SetMode(m.mode)
+	case termbox.KeySpace:
+		m.buffer.WriteRune(' ')
+	default:
+		m.buffer.WriteRune(ev.Ch)
+	}
+}
+
+func (m SearchMode) Exit() {}
+
+func (m SearchMode) Draw() {
+	m.editor.DrawStatus([]byte("/" + m.buffer.String()))
+}
+
+// Store the search term on the editor instance.
+// This allows us to use it later in other commands.
+func storeSearchTerm(e *editor.Editor, command string) error {
+	fields := strings.Fields(command)
+	term := fields[0]
+
+	e.LastSearchTerm = term
+
+	return nil
+}


### PR DESCRIPTION
When you press `/` in normal mode, you enter the new `SearchMode`, which simply allows you to enter your search term, and then stores that term in `Editor.LastSearchCommand`.

Then, when you press `n` or `N` in normal mode, it will use the `Search` command from `commands/search.go`.

Let me know if you have any feedback / thoughts on this. I think it works pretty well, and that it is open enough for other commands to make use of it, like you mentioned in #20 

Thanks!
