### PR TITLE
Add dedicated Selection class; make view track active selection.

### DIFF
--- a/buffer/cursor.go
+++ b/buffer/cursor.go
@@ -17,6 +17,11 @@ type Cursor struct {
 	Boffset int
 }
 
+type Range struct {
+	Start Cursor
+	End   Cursor
+}
+
 // Before reports whether the cursor is before other.
 func (c Cursor) Before(other Cursor) bool {
 	return c.LineNum < other.LineNum ||

--- a/commands/selection.go
+++ b/commands/selection.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
-	"github.com/kisielk/vigo/editor"
+//	"github.com/kisielk/vigo/editor"
 )
+
+/*
 
 type AdjustSelection struct {
 	Dir      Dir
@@ -100,3 +102,4 @@ func (cmd AdjustSelection) Apply(e *editor.Editor) {
 		v.SetVisualRange(vRange)
 	}
 }
+*/

--- a/view/view.go
+++ b/view/view.go
@@ -167,6 +167,62 @@ func NewTag(startLine, startOffset, endLine, endOffset int, fg, bg termbox.Attri
 	}
 }
 
+type SelectionType int
+
+const (
+	SelectionNone  SelectionType = 0
+	SelectionChar                = 1
+	SelectionLine                = 2
+	SelectionBlock               = 3
+)
+
+type Selection struct {
+	buffer.Range
+	Type SelectionType
+}
+
+func (s Selection) EffectiveRange() (r buffer.Range) {
+	r.Start, r.End = buffer.SortCursors(r.Start, r.End)
+	switch s.Type {
+	case SelectionChar:
+		// Inclusive -> exclusive range
+		r.End.NextRune(true)
+	case SelectionLine:
+		// Delete from the beginning of first line to the start of line after last.
+		r.Start.Boffset = 0
+		r.End.NextLine()
+		// XXX NextLine() sets Boffset to -1 which doesn't work for us,
+		// but gets specially handled in view.MoveCursorTo
+		r.End.Boffset = 0
+	case SelectionBlock:
+		// TODO Return a list of effective ranges. This will also work
+		// if we have sparse selection such as in Sublime Text
+		panic("not implemented")
+	}
+	return
+}
+
+func (s Selection) includes(c buffer.Cursor) bool {
+	if s.Type == SelectionNone {
+		return false
+	}
+
+	start, end := buffer.SortCursors(s.Start, s.End)
+	inc := false
+
+	switch s.Type {
+	case SelectionChar:
+		inc = (start.Before(c) || start.Equals(c)) && (c.Before(end) || c.Equals(end))
+	case SelectionLine:
+		inc = start.LineNum <= c.LineNum && c.LineNum <= end.LineNum
+	case SelectionBlock:
+		// TODO
+		panic("not implemented")
+	}
+
+	return inc
+}
+
 //----------------------------------------------------------------------------
 // view context
 //----------------------------------------------------------------------------
@@ -204,7 +260,7 @@ type View struct {
 	// statusBuf is a buffer used for drawing the status line
 	statusBuf bytes.Buffer
 
-	visualRange *Tag
+	selection      Selection
 	showHighlights bool
 
 	bufferEvents chan buffer.BufferEvent
@@ -232,12 +288,12 @@ func NewView(ctx Context, buf *buffer.Buffer, redraw chan struct{}) *View {
 	return v
 }
 
-func (v *View) VisualRange() *Tag {
-	return v.visualRange
+func (v *View) Selection() Selection {
+	return v.selection
 }
 
-func (v *View) SetVisualRange(t *Tag) {
-	v.visualRange = t
+func (v *View) SetSelection(r Selection) {
+	v.selection = r
 	v.dirty |= dirtyContents
 }
 
@@ -701,6 +757,11 @@ func (v *View) MoveCursorTo(c buffer.Cursor) {
 	v.cursor.LineNum = c.LineNum
 	v.adjustLineVoffset()
 	v.adjustTopLine()
+
+	if v.selection.Type != SelectionNone {
+		v.dirty |= dirtyContents
+		v.selection.End = v.Cursor()
+	}
 }
 
 // Move cursor to the beginning of the file (buffer).
@@ -884,12 +945,11 @@ func (v *View) tag(line, offset int) *Tag {
 func (v *View) makeCell(line, offset int, ch rune) termbox.Cell {
 	tag := v.tag(line, offset)
 
-	vRange := v.VisualRange()
-	if vRange != nil && vRange.includes(line, offset) {
+	if v.Selection().includes(buffer.Cursor{LineNum: line, Boffset: offset}) {
 		return termbox.Cell{
 			Ch: ch,
-			Fg: vRange.fg,
-			Bg: vRange.bg,
+			Fg: termbox.ColorDefault,
+			Bg: termbox.ColorDefault | termbox.AttrReverse,
 		}
 	}
 
@@ -961,30 +1021,4 @@ func (v *View) filterText(from, to buffer.Cursor, filter func([]byte) []byte) {
 	v.buf.Delete(c1, d)
 	data := filter(v.buf.History.LastAction().Data)
 	v.buf.Insert(c1, data)
-}
-
-func GetVisualSelection(v *View) (buffer.Cursor, buffer.Cursor) {
-	r := v.VisualRange()
-	startLine, startPos := r.StartPos()
-	endLine, endPos := r.EndPos()
-
-	start := buffer.Cursor{LineNum: startLine, Boffset: startPos}
-	end := buffer.Cursor{LineNum: endLine, Boffset: endPos}
-
-	line := v.Buffer().FirstLine
-	lineNum := 1
-
-	for line.Next != nil {
-		if lineNum == startLine {
-			start.Line = line
-		}
-
-		if lineNum == endLine {
-			end.Line = line
-		}
-		lineNum++
-		line = line.Next
-	}
-
-	return start, end
 }

--- a/view/view.go
+++ b/view/view.go
@@ -170,10 +170,10 @@ func NewTag(startLine, startOffset, endLine, endOffset int, fg, bg termbox.Attri
 type SelectionType int
 
 const (
-	SelectionNone  SelectionType = 0
-	SelectionChar                = 1
-	SelectionLine                = 2
-	SelectionBlock               = 3
+	SelectionNone SelectionType = iota
+	SelectionChar
+	SelectionLine
+	SelectionBlock
 )
 
 type Selection struct {
@@ -182,7 +182,7 @@ type Selection struct {
 }
 
 func (s Selection) EffectiveRange() (r buffer.Range) {
-	r.Start, r.End = buffer.SortCursors(r.Start, r.End)
+	r.Start, r.End = buffer.SortCursors(s.Start, s.End)
 	switch s.Type {
 	case SelectionChar:
 		// Inclusive -> exclusive range


### PR DESCRIPTION
First of all, big thanks to @gchp for the initial work. I wish I thought about this stuff during the original review, rather than after the fact. I have not yet removed any code to simplify the review.

Selection gives us an abstraction over a couple of implementation details
- Selection can be more complex than a non-interrupted buffer range (eg. block selection; we'll likely need a list of ranges to implement this). Separating overall selection and resulting buffer range(s) concepts creates a nice point where we can take care of all the grizzly conversion details (see EffectiveRange()) For instance, selection works on inclusive ranges, while normally ranges are end-exclusive.
- Having view update the selection as cursor is moved around makes sure the two don't get out of sync and removes the need for separate adjustment commands.

The change also attempts to make more use of Cursor object as opposed to line/offset arguments. Working with cursors is useful because some routines rely on Line field (eg. ExtractBytes), which is otherwise absent.
