### PR TITLE
editor: Finalize current action group when mode is set.

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -431,8 +431,7 @@ func (e *Editor) handleUIEvent(ev *termbox.Event) error {
 
 // SetMode sets active editor mode.
 // The specified mode instance will react to keys and other user input until
-// another mode is set. If previous mode type is not the same as current
-// one, current view buffer action group is finalized.
+// another mode is set.
 func (e *Editor) SetMode(m Mode) {
 	if e.mode != nil {
 		e.mode.Exit()

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 
 	"github.com/kisielk/vigo/buffer"
@@ -428,9 +429,16 @@ func (e *Editor) handleUIEvent(ev *termbox.Event) error {
 	return nil
 }
 
+// SetMode sets active editor mode.
+// The specified mode instance will react to keys and other user input until
+// another mode is set. If previous mode type is not the same as current
+// one, current view buffer action group is finalized.
 func (e *Editor) SetMode(m Mode) {
 	if e.mode != nil {
 		e.mode.Exit()
+		if reflect.TypeOf(e.mode) != reflect.TypeOf(m) {
+			e.ActiveView().Buffer().FinalizeActionGroup()
+		}
 	}
 	e.mode = m
 	e.overlay = nil

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 
 	"github.com/kisielk/vigo/buffer"
@@ -16,6 +15,7 @@ import (
 )
 
 type Mode interface {
+	Enter(e *Editor)
 	OnKey(ev *termbox.Event)
 	Exit()
 }
@@ -436,9 +436,6 @@ func (e *Editor) handleUIEvent(ev *termbox.Event) error {
 func (e *Editor) SetMode(m Mode) {
 	if e.mode != nil {
 		e.mode.Exit()
-		if reflect.TypeOf(e.mode) != reflect.TypeOf(m) {
-			e.ActiveView().Buffer().FinalizeActionGroup()
-		}
 	}
 	e.mode = m
 	e.overlay = nil
@@ -446,6 +443,7 @@ func (e *Editor) SetMode(m Mode) {
 	if o, ok := m.(Overlay); ok {
 		e.overlay = o
 	}
+	m.Enter(e)
 }
 
 func (e *Editor) viewContext() view.Context {

--- a/mode/command.go
+++ b/mode/command.go
@@ -22,6 +22,9 @@ func NewCommandMode(editor *editor.Editor, mode editor.Mode) CommandMode {
 	return m
 }
 
+func (m CommandMode) Enter(e *editor.Editor) {
+}
+
 func (m CommandMode) NeedsCursor() bool {
 	return true
 }
@@ -72,7 +75,7 @@ func execCommand(e *editor.Editor, command string) error {
 	}
 
 	cmd, args := fields[0], fields[1:]
-	
+
 	switch cmd {
 	case "q":
 		// TODO if more than one split, close active one only.

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -18,6 +18,9 @@ func NewInsertMode(editor *editor.Editor, count int) insertMode {
 	return m
 }
 
+func (m insertMode) Enter(editor *editor.Editor) {
+}
+
 func (m insertMode) OnKey(ev *termbox.Event) {
 	g := m.editor
 

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -18,6 +18,10 @@ func NewNormalMode(e *editor.Editor) *normalMode {
 	return &m
 }
 
+func (m *normalMode) Enter(e *editor.Editor) {
+	e.ActiveView().Buffer().FinalizeActionGroup()
+}
+
 func (m *normalMode) OnKey(ev *termbox.Event) {
 	// Most of the key bindings are derived from those at
 	// http://elvis.the-little-red-haired-girl.org/elvisman/elvisvi.html#index

--- a/mode/search.go
+++ b/mode/search.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kisielk/vigo/editor"
 	cmd "github.com/kisielk/vigo/commands"
+	"github.com/kisielk/vigo/editor"
 	"github.com/nsf/termbox-go"
 )
 
@@ -20,6 +20,9 @@ type SearchMode struct {
 func NewSearchMode(editor *editor.Editor, mode editor.Mode) SearchMode {
 	m := SearchMode{editor: editor, mode: mode, buffer: &bytes.Buffer{}}
 	return m
+}
+
+func (m SearchMode) Enter(e *editor.Editor) {
 }
 
 func (m SearchMode) NeedsCursor() bool {

--- a/mode/textobject.go
+++ b/mode/textobject.go
@@ -74,6 +74,9 @@ func NewTextObjectMode(editor *editor.Editor, mode editor.Mode, f buffer.RangeFu
 	}
 }
 
+func (m *TextObjectMode) Enter(e *editor.Editor) {
+}
+
 var ErrBadTextObject error = errors.New("bad text object")
 
 func (m *TextObjectMode) OnKey(ev *termbox.Event) {

--- a/mode/textobject.go
+++ b/mode/textobject.go
@@ -126,7 +126,6 @@ func (m *TextObjectMode) Exit() {
 			}
 			m.f(from, to)
 		}
-		v.Buffer().FinalizeActionGroup()
 	default:
 		m.editor.SetStatus("range conversion not implemented")
 	}

--- a/mode/visual.go
+++ b/mode/visual.go
@@ -37,6 +37,9 @@ func NewVisualMode(e *editor.Editor, lineMode bool) *visualMode {
 	return &m
 }
 
+func (m *visualMode) Enter(e *editor.Editor) {
+}
+
 func (m *visualMode) OnKey(ev *termbox.Event) {
 
 	// Consequtive non-zero digits specify action multiplier;

--- a/mode/window.go
+++ b/mode/window.go
@@ -15,6 +15,9 @@ func NewWindowMode(editor *editor.Editor, count int) WindowMode {
 	return WindowMode{editor: editor, count: count}
 }
 
+func (m WindowMode) Enter(e *editor.Editor) {
+}
+
 func (m WindowMode) OnKey(ev *termbox.Event) {
 	switch ev.Ch {
 	case 'h':


### PR DESCRIPTION
This simple rule restores correct undo behaviour on most commands (eg.
2d2w deletes 4 words and gets undone with a single 'u')
