### PR TITLE
Add support for clearing the count repetitions by pressing Esc

### DIFF
--- a/commands/modes.go
+++ b/commands/modes.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kisielk/vigo/editor"
 )
 type ResetMode struct {
-	Mode editor.EditorMode
+	Mode editor.Mode
 }
 
 func (m ResetMode) Apply(e *editor.Editor) {

--- a/commands/modes.go
+++ b/commands/modes.go
@@ -1,10 +1,17 @@
 package commands
 
-/*
 import (
 	"github.com/kisielk/vigo/editor"
 )
+type ResetMode struct {
+	Mode editor.EditorMode
+}
 
+func (m ResetMode) Apply(e *editor.Editor) {
+	m.Mode.Reset()
+}
+
+/*
 type EnterNormalMode struct{}
 
 func (_ EnterNormalMode) Apply(e *editor.Editor) {

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -18,6 +18,7 @@ type Mode interface {
 	Enter(e *Editor)
 	OnKey(ev *termbox.Event)
 	Exit()
+	Reset()
 }
 
 // this is a structure which represents a key press, used for keyboard macros
@@ -50,12 +51,6 @@ var ErrQuit = errors.New("quit")
 type Command interface {
 	Apply(*Editor)
 }
-
-type EditorMode interface {
-	Reset()
-	OnKey(*termbox.Event)
-}
-
 
 type Editor struct {
 	uiBuf       tulib.Buffer
@@ -438,17 +433,17 @@ func (e *Editor) handleUIEvent(ev *termbox.Event) error {
 // SetMode sets active editor mode.
 // The specified mode instance will react to keys and other user input until
 // another mode is set.
-func (e *Editor) SetMode(m Mode) {
+func (e *Editor) SetMode(m *Mode) {
 	if e.mode != nil {
 		e.mode.Exit()
 	}
-	e.mode = m
+	e.mode = *m
 	e.overlay = nil
 	// Some modes can be overlays.
-	if o, ok := m.(Overlay); ok {
+	if o, ok := (*m).(Overlay); ok {
 		e.overlay = o
 	}
-	m.Enter(e)
+	(*m).Enter(e)
 }
 
 func (e *Editor) viewContext() view.Context {

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -51,6 +51,12 @@ type Command interface {
 	Apply(*Editor)
 }
 
+type EditorMode interface {
+	Reset()
+	OnKey(*termbox.Event)
+}
+
+
 type Editor struct {
 	uiBuf       tulib.Buffer
 	active      *view.Tree // this one is always a leaf node

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -433,17 +433,17 @@ func (e *Editor) handleUIEvent(ev *termbox.Event) error {
 // SetMode sets active editor mode.
 // The specified mode instance will react to keys and other user input until
 // another mode is set.
-func (e *Editor) SetMode(m *Mode) {
+func (e *Editor) SetMode(m Mode) {
 	if e.mode != nil {
 		e.mode.Exit()
 	}
-	e.mode = *m
+	e.mode = m
 	e.overlay = nil
 	// Some modes can be overlays.
-	if o, ok := (*m).(Overlay); ok {
+	if o, ok := m.(Overlay); ok {
 		e.overlay = o
 	}
-	(*m).Enter(e)
+	m.Enter(e)
 }
 
 func (e *Editor) viewContext() view.Context {

--- a/mode/command.go
+++ b/mode/command.go
@@ -23,7 +23,7 @@ func NewCommandMode(editor *editor.Editor, mode editor.Mode) CommandMode {
 }
 
 func (m *CommandMode) Reset() {
-	m.editor.SetMode(&m.mode)
+	m.editor.SetMode(m.mode)
 }
 
 func (m *CommandMode) Enter(e *editor.Editor) {
@@ -54,7 +54,7 @@ func (m *CommandMode) OnKey(ev *termbox.Event) {
 		} else {
 			m.editor.SetStatus(":" + c)
 		}
-		m.editor.SetMode(&m.mode)
+		m.editor.SetMode(m.mode)
 	case termbox.KeySpace:
 		m.buffer.WriteRune(' ')
 	default:

--- a/mode/command.go
+++ b/mode/command.go
@@ -22,7 +22,11 @@ func NewCommandMode(editor *editor.Editor, mode editor.Mode) CommandMode {
 	return m
 }
 
-func (m CommandMode) Enter(e *editor.Editor) {
+func (m *CommandMode) Reset() {
+	m.editor.SetMode(&m.mode)
+}
+
+func (m *CommandMode) Enter(e *editor.Editor) {
 }
 
 func (m CommandMode) NeedsCursor() bool {
@@ -34,10 +38,10 @@ func (m CommandMode) CursorPosition() (int, int) {
 	return m.buffer.Len() + 1, e.Height() - 1
 }
 
-func (m CommandMode) OnKey(ev *termbox.Event) {
+func (m *CommandMode) OnKey(ev *termbox.Event) {
 	switch ev.Key {
 	case termbox.KeyEsc, termbox.KeyCtrlC:
-		m.editor.SetMode(m.mode)
+		m.Reset()
 	case termbox.KeyBackspace, termbox.KeyBackspace2:
 		l := m.buffer.Len()
 		if l > 0 {
@@ -50,7 +54,7 @@ func (m CommandMode) OnKey(ev *termbox.Event) {
 		} else {
 			m.editor.SetStatus(":" + c)
 		}
-		m.editor.SetMode(m.mode)
+		m.editor.SetMode(&m.mode)
 	case termbox.KeySpace:
 		m.buffer.WriteRune(' ')
 	default:

--- a/mode/command.go
+++ b/mode/command.go
@@ -17,9 +17,9 @@ type CommandMode struct {
 	buffer *bytes.Buffer
 }
 
-func NewCommandMode(editor *editor.Editor, mode editor.Mode) CommandMode {
+func NewCommandMode(editor *editor.Editor, mode editor.Mode) *CommandMode {
 	m := CommandMode{editor: editor, mode: mode, buffer: &bytes.Buffer{}}
-	return m
+	return &m
 }
 
 func (m *CommandMode) Reset() {

--- a/mode/command.go
+++ b/mode/command.go
@@ -22,10 +22,11 @@ func NewCommandMode(editor *editor.Editor, mode editor.Mode) *CommandMode {
 	return &m
 }
 
+// Reset (NOOP)
 func (m *CommandMode) Reset() {
-	m.editor.SetMode(m.mode)
 }
 
+// Enter (NOOP)
 func (m *CommandMode) Enter(e *editor.Editor) {
 }
 
@@ -41,7 +42,7 @@ func (m CommandMode) CursorPosition() (int, int) {
 func (m *CommandMode) OnKey(ev *termbox.Event) {
 	switch ev.Key {
 	case termbox.KeyEsc, termbox.KeyCtrlC:
-		m.Reset()
+		m.Exit()
 	case termbox.KeyBackspace, termbox.KeyBackspace2:
 		l := m.buffer.Len()
 		if l > 0 {
@@ -62,7 +63,13 @@ func (m *CommandMode) OnKey(ev *termbox.Event) {
 	}
 }
 
+// Exit Set the mode to self the 'prior' mode
+// EG- if NewCommandMode was called from normal mode,
+// cmdMode := NewCommandMode(g, m) where g is *Editor,
+// m is editor.Mode (interface)
+// you would go back to that mode
 func (m CommandMode) Exit() {
+	m.editor.SetMode(m.mode)
 }
 
 func (m CommandMode) Draw() {

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -29,11 +29,12 @@ func (m *InsertMode) Exit() {
 	}
 }
 
-func NewInsertMode(editor *editor.Editor, count int) (m *InsertMode) {
+func NewInsertMode(editor *editor.Editor, count int) *InsertMode {
+	var m *InsertMode
 	m = &InsertMode{editor: editor}
 	m.editor.SetStatus("Insert")
 	m.count = count
-	return
+	return m
 }
 
 func (m *InsertMode) OnKey(ev *termbox.Event) {

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -4,7 +4,6 @@ import (
 	cmd "github.com/kisielk/vigo/commands"
 	"github.com/kisielk/vigo/editor"
 	"github.com/nsf/termbox-go"
-	"time"
 )
 
 type InsertMode struct {
@@ -36,48 +35,25 @@ func NewInsertMode(editor *editor.Editor, count int) (m *InsertMode) {
 }
 
 func (m *InsertMode) OnKey(ev *termbox.Event) {
-	if ev.Key == termbox.KeyEsc || ev.Key == termbox.KeyCtrlC {
-		m.editor.SetMode(NewNormalMode(m.editor))
-		return
-	}
-
-	var eventChan = make(chan *termbox.Event)
-
 	g := m.editor
 
-	go m.getCommand(g.Commands, eventChan)
-
-	eventChan <- ev
-
-	close(eventChan)
-}
-
-func (m *InsertMode) getCommand(commandChan chan<- editor.Command, eventChan <-chan *termbox.Event) {
-
-	var ev *termbox.Event
-
-	select {
-	case ev = <-eventChan:
-		switch ev.Key {
-		case termbox.KeyBackspace, termbox.KeyBackspace2:
-			commandChan <- cmd.DeleteRuneBackward{}
-		case termbox.KeyDelete, termbox.KeyCtrlD:
-			commandChan <- cmd.DeleteRune{}
-		case termbox.KeySpace:
-			commandChan <- cmd.InsertRune{' '}
-		case termbox.KeyEnter:
-			// we use '\r' for <enter>, because it doesn't cause autoindent
-			commandChan <- cmd.InsertRune{'\r'}
-		case termbox.KeyCtrlJ:
-			commandChan <- cmd.InsertRune{'\n'}
-		default:
-			if ev.Ch != 0 {
-				commandChan <- cmd.InsertRune{ev.Ch}
-			}
+	switch ev.Key {
+	case termbox.KeyEsc, termbox.KeyCtrlC:
+		g.SetMode(NewNormalMode(g))
+	case termbox.KeyBackspace, termbox.KeyBackspace2:
+		g.Commands <- cmd.DeleteRuneBackward{}
+	case termbox.KeyDelete, termbox.KeyCtrlD:
+		g.Commands <- cmd.DeleteRune{}
+	case termbox.KeySpace:
+		g.Commands <- cmd.InsertRune{' '}
+	case termbox.KeyEnter:
+		// we use '\r' for <enter>, because it doesn't cause autoindent
+		g.Commands <- cmd.InsertRune{'\r'}
+	case termbox.KeyCtrlJ:
+		g.Commands <- cmd.InsertRune{'\n'}
+	default:
+		if ev.Ch != 0 {
+			g.Commands <- cmd.InsertRune{ev.Ch}
 		}
-	case <-time.After(time.Nanosecond * 500 * 1000000):
-		commandChan <- cmd.ResetMode{Mode: m}
 	}
-	close(commandChan)
 }
-

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -28,11 +28,11 @@ func (m *InsertMode) Exit() {
 	}
 }
 
-func NewInsertMode(editor *editor.Editor, count int) InsertMode {
-	m := InsertMode{editor: editor}
+func NewInsertMode(editor *editor.Editor, count int) (m *InsertMode) {
+	m = &InsertMode{editor: editor}
 	m.editor.SetStatus("Insert")
 	m.count = count
-	return m
+	return
 }
 
 func (m *InsertMode) OnKey(ev *termbox.Event) {

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -36,10 +36,8 @@ func NewInsertMode(editor *editor.Editor, count int) InsertMode {
 }
 
 func (m *InsertMode) OnKey(ev *termbox.Event) {
-	var newMode editor.Mode
 	if ev.Key == termbox.KeyEsc || ev.Key == termbox.KeyCtrlC {
-		newMode = NewNormalMode(m.editor)
-		m.editor.SetMode(&newMode)
+		m.editor.SetMode(NewNormalMode(m.editor))
 		return
 	}
 

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -4,6 +4,7 @@ import (
 	cmd "github.com/kisielk/vigo/commands"
 	"github.com/kisielk/vigo/editor"
 	"github.com/nsf/termbox-go"
+	"time"
 )
 
 type insertMode struct {
@@ -21,28 +22,54 @@ func NewInsertMode(editor *editor.Editor, count int) insertMode {
 func (m insertMode) Enter(editor *editor.Editor) {
 }
 
+func (m insertMode) Reset() {
+
+}
+
 func (m insertMode) OnKey(ev *termbox.Event) {
+	if ev.Key == termbox.KeyEsc || ev.Key == termbox.KeyCtrlC {
+		m.editor.SetMode(NewNormalMode(m.editor))
+		return
+	}
+
+	var eventChan = make(chan *termbox.Event)
+
 	g := m.editor
 
-	switch ev.Key {
-	case termbox.KeyEsc, termbox.KeyCtrlC:
-		g.SetMode(NewNormalMode(g))
-	case termbox.KeyBackspace, termbox.KeyBackspace2:
-		g.Commands <- cmd.DeleteRuneBackward{}
-	case termbox.KeyDelete, termbox.KeyCtrlD:
-		g.Commands <- cmd.DeleteRune{}
-	case termbox.KeySpace:
-		g.Commands <- cmd.InsertRune{' '}
-	case termbox.KeyEnter:
-		// we use '\r' for <enter>, because it doesn't cause autoindent
-		g.Commands <- cmd.InsertRune{'\r'}
-	case termbox.KeyCtrlJ:
-		g.Commands <- cmd.InsertRune{'\n'}
-	default:
-		if ev.Ch != 0 {
-			g.Commands <- cmd.InsertRune{ev.Ch}
+	go m.getCommand(g.Commands, eventChan)
+
+	eventChan <- ev
+
+	close(eventChan)
+}
+
+func (m insertMode) getCommand(commandChan chan<- editor.Command, eventChan <-chan *termbox.Event) {
+
+	var ev *termbox.Event
+
+	select {
+	case ev = <-eventChan:
+		switch ev.Key {
+		case termbox.KeyBackspace, termbox.KeyBackspace2:
+			commandChan <- cmd.DeleteRuneBackward{}
+		case termbox.KeyDelete, termbox.KeyCtrlD:
+			commandChan <- cmd.DeleteRune{}
+		case termbox.KeySpace:
+			commandChan <- cmd.InsertRune{' '}
+		case termbox.KeyEnter:
+			// we use '\r' for <enter>, because it doesn't cause autoindent
+			commandChan <- cmd.InsertRune{'\r'}
+		case termbox.KeyCtrlJ:
+			commandChan <- cmd.InsertRune{'\n'}
+		default:
+			if ev.Ch != 0 {
+				commandChan <- cmd.InsertRune{ev.Ch}
+			}
 		}
+	case <-time.After(time.Nanosecond * 500 * 1000000):
+		commandChan <- cmd.ResetMode{Mode: m}
 	}
+	close(commandChan)
 }
 
 func (m insertMode) Exit() {

--- a/mode/insert.go
+++ b/mode/insert.go
@@ -11,6 +11,8 @@ type InsertMode struct {
 	count  int
 }
 
+// Reset (NOOP): in InsertMode reset is kind of meaningless
+// Kept for Interface reasons.
 func (m *InsertMode) Reset() {
 }
 

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -56,7 +56,7 @@ func (m *NormalMode) OnKey(ev *termbox.Event) {
 	case 0x0:
 		switch ev.Key {
 		case termbox.KeyEsc:
-      m.Reset()
+			g.Commands <- cmd.ResetMode{Mode: m}
       return
 		}
 	}

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -32,6 +32,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	// Most of the key bindings are derived from those at
 	// http://elvis.the-little-red-haired-girl.org/elvisman/elvisvi.html#index
 
+	var newMode editor.Mode
+
 	g := m.editor
 	v := g.ActiveView()
 	c := v.Cursor()
@@ -113,7 +115,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 			return
 		case termbox.KeyCtrlW:
 			// TODO Use count for window width/height
-			g.SetMode(NewWindowMode(g, count))
+			newMode = NewWindowMode(g, count)
+			g.SetMode(&newMode)
 		case termbox.KeyCtrlX:
 			// TODO: Move to column count
 			return
@@ -126,13 +129,15 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		}
 	case 'A':
 		g.Commands <- cmd.MoveEOL{}
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'B':
 		// TODO: Distinction from 'b'
 		g.Commands <- cmd.Repeat{cmd.MoveWord{Dir: cmd.Backward}, count}
 	case 'C':
 		g.Commands <- cmd.DeleteEOL{}
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'D':
 		g.Commands <- cmd.DeleteEOL{}
 	case 'E':
@@ -149,7 +154,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		return
 	case 'I':
 		g.Commands <- cmd.MoveFOL{}
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'J':
 		// TODO: Join lines, whitespace separated
 		return
@@ -166,7 +172,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		g.Commands <- cmd.Search{Dir: cmd.Backward}
 	case 'O':
 		g.Commands <- cmd.Repeat{cmd.NewLine{Dir: cmd.Backward}, count}
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'P':
 		// TODO: Paste text before cursor
 		return
@@ -207,7 +214,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		g.Commands <- cmd.Repeat{cmd.MoveRune{Dir: cmd.Forward, Wrap: false}, count}
 	case 'o':
 		g.Commands <- cmd.Repeat{cmd.NewLine{Dir: cmd.Forward}, count}
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'w':
 		g.Commands <- cmd.Repeat{cmd.MoveWord{Dir: cmd.Forward}, count}
 	case 'e':
@@ -227,15 +235,20 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	switch ev.Ch {
 	case 'a':
 		g.Commands <- cmd.MoveRune{Dir: cmd.Forward, Wrap: false}
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'd':
-		g.SetMode(NewTextObjectMode(g, m, v.Buffer().DeleteRange, count))
+		newMode = NewTextObjectMode(g, m, v.Buffer().DeleteRange, count)
+		g.SetMode(&newMode)
 	case 'i':
-		g.SetMode(NewInsertMode(g, count))
+		newMode = NewInsertMode(g, count)
+		g.SetMode(&newMode)
 	case 'v':
-		g.SetMode(NewVisualMode(g, false))
+		newMode = NewVisualMode(g, false)
+		g.SetMode(&newMode)
 	case 'V':
-		g.SetMode(NewVisualMode(g, true))
+		newMode = NewVisualMode(g, false)
+		g.SetMode(&newMode)
 	case ':':
 		// TODO use count to set range for command mode
 		g.SetMode(NewCommandMode(g, m))

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -7,28 +7,28 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
-type normalMode struct {
+type NormalMode struct {
 	editor  *editor.Editor
 	count   string
 	command editor.Command
 }
 
-func NewNormalMode(e *editor.Editor) *normalMode {
-	m := normalMode{editor: e}
+func NewNormalMode(e *editor.Editor) *NormalMode {
+	m := NormalMode{editor: e}
 	m.editor.SetStatus("Normal")
 	return &m
 }
 
-func (m *normalMode) Enter(e *editor.Editor) {
+func (m *NormalMode) Enter(e *editor.Editor) {
 	e.ActiveView().Buffer().FinalizeActionGroup()
 }
 
-func (m *normalMode) Reset() {
+func (m *NormalMode) Reset() {
 	m.count = ""
 	m.command = nil
 }
 
-func (m *normalMode) OnKey(ev *termbox.Event) {
+func (m *NormalMode) OnKey(ev *termbox.Event) {
 	// Most of the key bindings are derived from those at
 	// http://elvis.the-little-red-haired-girl.org/elvisman/elvisvi.html#index
 
@@ -247,5 +247,5 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
   m.Reset()
 }
 
-func (m *normalMode) Exit() {
+func (m *NormalMode) Exit() {
 }

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -32,8 +32,6 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	// Most of the key bindings are derived from those at
 	// http://elvis.the-little-red-haired-girl.org/elvisman/elvisvi.html#index
 
-	var newMode editor.Mode
-
 	g := m.editor
 	v := g.ActiveView()
 	c := v.Cursor()
@@ -115,8 +113,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 			return
 		case termbox.KeyCtrlW:
 			// TODO Use count for window width/height
-			newMode = NewWindowMode(g, count)
-			g.SetMode(&newMode)
+			g.SetMode(NewWindowMode(g, count))
 		case termbox.KeyCtrlX:
 			// TODO: Move to column count
 			return
@@ -129,15 +126,13 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		}
 	case 'A':
 		g.Commands <- cmd.MoveEOL{}
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'B':
 		// TODO: Distinction from 'b'
 		g.Commands <- cmd.Repeat{cmd.MoveWord{Dir: cmd.Backward}, count}
 	case 'C':
 		g.Commands <- cmd.DeleteEOL{}
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'D':
 		g.Commands <- cmd.DeleteEOL{}
 	case 'E':
@@ -154,8 +149,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		return
 	case 'I':
 		g.Commands <- cmd.MoveFOL{}
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'J':
 		// TODO: Join lines, whitespace separated
 		return
@@ -172,8 +166,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		g.Commands <- cmd.Search{Dir: cmd.Backward}
 	case 'O':
 		g.Commands <- cmd.Repeat{cmd.NewLine{Dir: cmd.Backward}, count}
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'P':
 		// TODO: Paste text before cursor
 		return
@@ -214,8 +207,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		g.Commands <- cmd.Repeat{cmd.MoveRune{Dir: cmd.Forward, Wrap: false}, count}
 	case 'o':
 		g.Commands <- cmd.Repeat{cmd.NewLine{Dir: cmd.Forward}, count}
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'w':
 		g.Commands <- cmd.Repeat{cmd.MoveWord{Dir: cmd.Forward}, count}
 	case 'e':
@@ -235,20 +227,15 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	switch ev.Ch {
 	case 'a':
 		g.Commands <- cmd.MoveRune{Dir: cmd.Forward, Wrap: false}
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'd':
-		newMode = NewTextObjectMode(g, m, v.Buffer().DeleteRange, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewTextObjectMode(g, m, v.Buffer().DeleteRange, count))
 	case 'i':
-		newMode = NewInsertMode(g, count)
-		g.SetMode(&newMode)
+		g.SetMode(NewInsertMode(g, count))
 	case 'v':
-		newMode = NewVisualMode(g, false)
-		g.SetMode(&newMode)
+		g.SetMode(NewVisualMode(g, false))
 	case 'V':
-		newMode = NewVisualMode(g, false)
-		g.SetMode(&newMode)
+		g.SetMode(NewVisualMode(g, false))
 	case ':':
 		// TODO use count to set range for command mode
 		g.SetMode(NewCommandMode(g, m))

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -23,6 +23,11 @@ func (m *normalMode) Enter(e *editor.Editor) {
 	e.ActiveView().Buffer().FinalizeActionGroup()
 }
 
+func (m *normalMode) Reset() {
+	m.count = ""
+	m.command = nil
+}
+
 func (m *normalMode) OnKey(ev *termbox.Event) {
 	// Most of the key bindings are derived from those at
 	// http://elvis.the-little-red-haired-girl.org/elvisman/elvisvi.html#index
@@ -51,9 +56,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	case 0x0:
 		switch ev.Key {
 		case termbox.KeyEsc:
-			m.count = ""
-			m.command = nil
-			return
+      m.Reset()
+      return
 		}
 	}
 
@@ -240,8 +244,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	}
 
 	// Reset repetitions
-	m.count = ""
-	m.command = nil
+  m.Reset()
 }
 
 func (m *normalMode) Exit() {

--- a/mode/normal.go
+++ b/mode/normal.go
@@ -8,8 +8,9 @@ import (
 )
 
 type normalMode struct {
-	editor *editor.Editor
-	count  string
+	editor  *editor.Editor
+	count   string
+	command editor.Command
 }
 
 func NewNormalMode(e *editor.Editor) *normalMode {
@@ -42,6 +43,18 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 	count := utils.ParseCount(m.count)
 	if count == 0 {
 		count = 1
+	}
+
+	// Consecutive comands that require futher input to complete;
+	// accumulate and return.  Accept escape to reset the command
+	switch ev.Ch {
+	case 0x0:
+		switch ev.Key {
+		case termbox.KeyEsc:
+			m.count = ""
+			m.command = nil
+			return
+		}
 	}
 
 	// TODO: For (half)screen moving commands, use view.Height() in
@@ -103,9 +116,6 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		case termbox.KeyCtrlY:
 			// TODO: should move by count lines, default to 1
 			g.Commands <- cmd.MoveView{Dir: cmd.Backward, Lines: 1}
-		case termbox.KeyEsc:
-			// TODO: Cancel the current command
-			return
 		case termbox.KeySpace:
 			// Same as 'l'
 			g.Commands <- cmd.Repeat{cmd.MoveRune{Dir: cmd.Forward, Wrap: false}, count}
@@ -125,7 +135,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		// TODO: Distinction from 'e'
 		g.Commands <- cmd.Repeat{cmd.MoveWordEnd{}, count}
 	case 'F':
-		// TODO: Move left to given character
+		// TODO: Distinction from 'f' - move the the first (nth) occurence of following rune
 		return
 	case 'G':
 		// TODO: Move to line #, default last line
@@ -198,6 +208,8 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 		g.Commands <- cmd.Repeat{cmd.MoveWord{Dir: cmd.Forward}, count}
 	case 'e':
 		g.Commands <- cmd.Repeat{cmd.MoveWordEnd{}, count}
+	case 'f':
+		// TODO: Move to first (nth) occurance of entered rune to the right
 	case 'b':
 		g.Commands <- cmd.Repeat{cmd.MoveWord{Dir: cmd.Backward}, count}
 	case 'x':
@@ -229,6 +241,7 @@ func (m *normalMode) OnKey(ev *termbox.Event) {
 
 	// Reset repetitions
 	m.count = ""
+	m.command = nil
 }
 
 func (m *normalMode) Exit() {

--- a/mode/search.go
+++ b/mode/search.go
@@ -33,8 +33,12 @@ func (m *SearchMode) CursorPosition() (int, int) {
 	return m.buffer.Len() + 1, e.Height() - 1
 }
 
-func (m *SearchMode) Reset () {
+// Reset NOOP
+func (m *SearchMode) Reset() {
 }
+
+// Exit NOOP
+func (m *SearchMode) Exit() {}
 
 func (m *SearchMode) OnKey(ev *termbox.Event) {
 	switch ev.Key {
@@ -57,8 +61,6 @@ func (m *SearchMode) OnKey(ev *termbox.Event) {
 		m.buffer.WriteRune(ev.Ch)
 	}
 }
-
-func (m *SearchMode) Exit() {}
 
 func (m *SearchMode) Draw() {
 	m.editor.DrawStatus([]byte("/" + m.buffer.String()))

--- a/mode/search.go
+++ b/mode/search.go
@@ -16,9 +16,9 @@ type SearchMode struct {
 	buffer *bytes.Buffer
 }
 
-func NewSearchMode(editor *editor.Editor, mode editor.Mode) SearchMode {
+func NewSearchMode(editor *editor.Editor, mode editor.Mode) *SearchMode {
 	m := SearchMode{editor: editor, mode: mode, buffer: &bytes.Buffer{}}
-	return m
+	return &m
 }
 
 func (m *SearchMode) Enter(e *editor.Editor) {

--- a/mode/search.go
+++ b/mode/search.go
@@ -21,19 +21,22 @@ func NewSearchMode(editor *editor.Editor, mode editor.Mode) SearchMode {
 	return m
 }
 
-func (m SearchMode) Enter(e *editor.Editor) {
+func (m *SearchMode) Enter(e *editor.Editor) {
 }
 
-func (m SearchMode) NeedsCursor() bool {
+func (m *SearchMode) NeedsCursor() bool {
 	return true
 }
 
-func (m SearchMode) CursorPosition() (int, int) {
+func (m *SearchMode) CursorPosition() (int, int) {
 	e := m.editor
 	return m.buffer.Len() + 1, e.Height() - 1
 }
 
-func (m SearchMode) OnKey(ev *termbox.Event) {
+func (m *SearchMode) Reset () {
+}
+
+func (m *SearchMode) OnKey(ev *termbox.Event) {
 	switch ev.Key {
 	case termbox.KeyEsc, termbox.KeyCtrlC:
 		m.editor.SetMode(m.mode)
@@ -55,9 +58,9 @@ func (m SearchMode) OnKey(ev *termbox.Event) {
 	}
 }
 
-func (m SearchMode) Exit() {}
+func (m *SearchMode) Exit() {}
 
-func (m SearchMode) Draw() {
+func (m *SearchMode) Draw() {
 	m.editor.DrawStatus([]byte("/" + m.buffer.String()))
 }
 

--- a/mode/textobject.go
+++ b/mode/textobject.go
@@ -133,3 +133,6 @@ func (m *TextObjectMode) Exit() {
 		m.editor.SetStatus("range conversion not implemented")
 	}
 }
+
+func (m *TextObjectMode) Reset() {
+}

--- a/mode/textobject.go
+++ b/mode/textobject.go
@@ -110,6 +110,7 @@ loop:
 	}
 }
 
+// Exit ... does... what?
 func (m *TextObjectMode) Exit() {
 	if m.err != nil {
 		m.editor.SetStatus(m.err.Error())
@@ -134,5 +135,6 @@ func (m *TextObjectMode) Exit() {
 	}
 }
 
+// Reset (NOOP)
 func (m *TextObjectMode) Reset() {
 }

--- a/mode/visual.go
+++ b/mode/visual.go
@@ -8,14 +8,14 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
-type visualMode struct {
+type VisualMode struct {
 	editor   *editor.Editor
 	count    string
 	lineMode bool
 }
 
-func NewVisualMode(e *editor.Editor, lineMode bool) visualMode {
-	m := visualMode{editor: e, lineMode: lineMode}
+func NewVisualMode(e *editor.Editor, lineMode bool) VisualMode {
+	m := VisualMode{editor: e, lineMode: lineMode}
 	v := m.editor.ActiveView()
 	c := v.Cursor()
 
@@ -37,10 +37,10 @@ func NewVisualMode(e *editor.Editor, lineMode bool) visualMode {
 	return m
 }
 
-func (m *visualMode) Enter(e *editor.Editor) {
+func (m *VisualMode) Enter(e *editor.Editor) {
 }
 
-func (m *visualMode) OnKey(ev *termbox.Event) {
+func (m *VisualMode) OnKey(ev *termbox.Event) {
 
 	// Consequtive non-zero digits specify action multiplier;
 	// accumulate and return. Accept zero only if it's
@@ -90,11 +90,11 @@ func (m *visualMode) OnKey(ev *termbox.Event) {
 	m.Reset()
 }
 
-func (m *visualMode) Reset() {
+func (m *VisualMode) Reset() {
   m.count = ""
 }
 
-func (m *visualMode) Exit() {
+func (m *VisualMode) Exit() {
 	v := m.editor.ActiveView()
 	v.SetSelection(view.Selection{Type: view.SelectionNone})
 }

--- a/mode/visual.go
+++ b/mode/visual.go
@@ -90,10 +90,12 @@ func (m *VisualMode) OnKey(ev *termbox.Event) {
 	m.Reset()
 }
 
+// Reset the count state.
 func (m *VisualMode) Reset() {
-  m.count = ""
+	m.count = ""
 }
 
+// Exit visual mode by setting the selection to none.
 func (m *VisualMode) Exit() {
 	v := m.editor.ActiveView()
 	v.SetSelection(view.Selection{Type: view.SelectionNone})

--- a/mode/visual.go
+++ b/mode/visual.go
@@ -14,7 +14,7 @@ type visualMode struct {
 	lineMode bool
 }
 
-func NewVisualMode(e *editor.Editor, lineMode bool) *visualMode {
+func NewVisualMode(e *editor.Editor, lineMode bool) visualMode {
 	m := visualMode{editor: e, lineMode: lineMode}
 	v := m.editor.ActiveView()
 	c := v.Cursor()
@@ -34,7 +34,7 @@ func NewVisualMode(e *editor.Editor, lineMode bool) *visualMode {
 
 	v.SetSelection(sel)
 
-	return &m
+	return m
 }
 
 func (m *visualMode) Enter(e *editor.Editor) {
@@ -87,7 +87,11 @@ func (m *visualMode) OnKey(ev *termbox.Event) {
 		}
 	}
 
-	m.count = ""
+	m.Reset()
+}
+
+func (m *visualMode) Reset() {
+  m.count = ""
 }
 
 func (m *visualMode) Exit() {

--- a/mode/visual.go
+++ b/mode/visual.go
@@ -14,7 +14,7 @@ type VisualMode struct {
 	lineMode bool
 }
 
-func NewVisualMode(e *editor.Editor, lineMode bool) VisualMode {
+func NewVisualMode(e *editor.Editor, lineMode bool) *VisualMode {
 	m := VisualMode{editor: e, lineMode: lineMode}
 	v := m.editor.ActiveView()
 	c := v.Cursor()
@@ -34,7 +34,7 @@ func NewVisualMode(e *editor.Editor, lineMode bool) VisualMode {
 
 	v.SetSelection(sel)
 
-	return m
+	return &m
 }
 
 func (m *VisualMode) Enter(e *editor.Editor) {

--- a/mode/window.go
+++ b/mode/window.go
@@ -15,9 +15,12 @@ func NewWindowMode(editor *editor.Editor, count int) *WindowMode {
 	return &WindowMode{editor: editor, count: count}
 }
 
+// Reset (NOOP)
 func (m *WindowMode) Reset() {
 }
 
+// Exit (NOOP)
+//TODO should this close the window / split?
 func (m *WindowMode) Exit() {
 }
 

--- a/mode/window.go
+++ b/mode/window.go
@@ -11,8 +11,8 @@ type WindowMode struct {
 	count  int
 }
 
-func NewWindowMode(editor *editor.Editor, count int) WindowMode {
-	return WindowMode{editor: editor, count: count}
+func NewWindowMode(editor *editor.Editor, count int) *WindowMode {
+	return &WindowMode{editor: editor, count: count}
 }
 
 func (m *WindowMode) Reset() {

--- a/mode/window.go
+++ b/mode/window.go
@@ -11,14 +11,21 @@ type WindowMode struct {
 	count  int
 }
 
+func (m *WindowMode) Reset() {
+}
+
+func (m *WindowMode) Exit() {
+}
+
+func (m *WindowMode) Enter(e *editor.Editor) {
+}
+
 func NewWindowMode(editor *editor.Editor, count int) WindowMode {
 	return WindowMode{editor: editor, count: count}
 }
 
-func (m WindowMode) Enter(e *editor.Editor) {
-}
 
-func (m WindowMode) OnKey(ev *termbox.Event) {
+func (m *WindowMode) OnKey(ev *termbox.Event) {
 	switch ev.Ch {
 	case 'h':
 		m.editor.Commands <- cmd.NearestVSplit{cmd.Backward}
@@ -34,5 +41,3 @@ func (m WindowMode) OnKey(ev *termbox.Event) {
 	m.editor.SetMode(NewNormalMode(m.editor))
 }
 
-func (m WindowMode) Exit() {
-}

--- a/mode/window.go
+++ b/mode/window.go
@@ -11,6 +11,10 @@ type WindowMode struct {
 	count  int
 }
 
+func NewWindowMode(editor *editor.Editor, count int) WindowMode {
+	return WindowMode{editor: editor, count: count}
+}
+
 func (m *WindowMode) Reset() {
 }
 
@@ -19,11 +23,6 @@ func (m *WindowMode) Exit() {
 
 func (m *WindowMode) Enter(e *editor.Editor) {
 }
-
-func NewWindowMode(editor *editor.Editor, count int) WindowMode {
-	return WindowMode{editor: editor, count: count}
-}
-
 
 func (m *WindowMode) OnKey(ev *termbox.Event) {
 	switch ev.Ch {
@@ -40,4 +39,3 @@ func (m *WindowMode) OnKey(ev *termbox.Event) {
 	}
 	m.editor.SetMode(NewNormalMode(m.editor))
 }
-


### PR DESCRIPTION
Moved the check for pressing Esc to before where the command event keys are processed - and it will clear out the number of repetitions entered.

This was going to be part of implementing F and f as commands: Both of which require you to be able to enter addtional characters after the command.  

First pass didn't work so well, so here is just the escape part.
