### PR TITLE
Change how status strings are formated and printed

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -457,6 +457,10 @@ func (b *Buffer) SaveAs(filename string) error {
 		return error( fmt.Errorf("couldn't determine absolute path: %s", err))
 	}
 
+	if b.Path == "" {
+		b.Path = fullpath
+	}
+
 	r := b.reader()
 	f, err := os.Create(filename)
 	if err != nil {
@@ -470,9 +474,6 @@ func (b *Buffer) SaveAs(filename string) error {
 	}
 
 	b.onDisk = b.History
-	if b.Path != ""{
-		b.Path = fullpath
-	}
 	b.Emit(BufferEvent{Type: BufferEventSave})
 
 	return nil

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"unicode/utf8"
+	"path/filepath"
 
 	"github.com/kisielk/vigo/utils"
 )
@@ -451,6 +452,11 @@ func (b *Buffer) SaveAs(filename string) error {
 	b.CleanupTrailingNewlines()
 	b.EnsureTrailingEOL()
 
+	fullpath, err := filepath.Abs(filename)
+	if err != nil {
+		return error( fmt.Errorf("couldn't determine absolute path: %s", err))
+	}
+
 	r := b.reader()
 	f, err := os.Create(filename)
 	if err != nil {
@@ -464,6 +470,8 @@ func (b *Buffer) SaveAs(filename string) error {
 	}
 
 	b.onDisk = b.History
+	b.Name = filename
+	b.Path = fullpath
 	b.Emit(BufferEvent{Type: BufferEventSave})
 
 	return nil

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -470,8 +470,9 @@ func (b *Buffer) SaveAs(filename string) error {
 	}
 
 	b.onDisk = b.History
-	b.Name = filename
-	b.Path = fullpath
+	if b.Path != ""{
+		b.Path = fullpath
+	}
 	b.Emit(BufferEvent{Type: BufferEventSave})
 
 	return nil

--- a/commands/buffer.go
+++ b/commands/buffer.go
@@ -12,13 +12,19 @@ type SaveBuffer struct {
 
 func (t SaveBuffer) Apply(e *editor.Editor) {
 	var err error
+		if t.Buf.Name == "unnamed" && t.Buf.Path == "" {
+			t.Buf.Name = e.BufferName(t.Filename)
+		}
 	if t.Filename != "" {
 		err = t.Buf.SaveAs(t.Filename)
 		if err != nil {
+			t.Buf.Name = "unnamed"  // reset the name... something went wrong
 			e.SetStatus(err)
 		}
-		if t.Buf.Name == "" {
-			t.Buf.Name = e.BufferName(t.Filename)
+	} else {
+		err = t.Buf.Save()
+		if err != nil {
+			e.SetStatus(err)
 		}
 	}
 }

--- a/commands/buffer.go
+++ b/commands/buffer.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"github.com/kisielk/vigo/editor"
+	"github.com/kisielk/vigo/buffer"
+)
+
+type SaveBuffer struct {
+	Buf *buffer.Buffer
+	Filename string
+}
+
+func (t SaveBuffer) Apply(e *editor.Editor) {
+	var err error
+	if t.Filename != "" {
+		err = t.Buf.SaveAs(t.Filename)
+		if err != nil {
+			e.SetStatus(err)
+		}
+		if t.Buf.Name == "" {
+			t.Buf.Name = e.BufferName(t.Filename)
+		}
+	}
+}

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -21,7 +21,7 @@ type Mode interface {
 	Exit()
 }
 
-const EDITOR_STATUS_TEMPLATE = `{{range .Messages}} {{ . }} {{ end }}`
+const editorStatusTemplate = `{{range .Messages}} {{ . }} {{ end }}`
 
 // this is a structure which represents a key press, used for keyboard macros
 type keyEvent struct {
@@ -97,10 +97,7 @@ func NewEditor(filenames []string) *Editor {
 	e.buffers = make([]*buffer.Buffer, 0, 20)
 	e.cutBuffers = newCutBuffers()
 
-	tmp, err := template.New("status").Parse(EDITOR_STATUS_TEMPLATE)
-	if err != nil {
-		panic(fmt.Errorf("Bad template string: %s", err))
-	}
+	tmp := template.Must(template.New("status").Parse(editorStatusTemplate))
 	e.StatusTemplate = *tmp
 
 	for _, filename := range filenames {
@@ -190,7 +187,7 @@ func (e *Editor) SetStatus(args ...interface{}) {
 	e.statusBuf.Reset()
 	data := struct {
 		Messages []interface{}
-	} {
+	}{
 		args}
 	e.StatusTemplate.Execute(&e.statusBuf, data)
 }

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -109,7 +109,7 @@ func NewEditor(filenames []string) *Editor {
 	}
 	if len(e.buffers) == 0 {
 		buf := buffer.NewEmptyBuffer()
-		buf.Name = e.bufferName("unnamed")
+		buf.Name = e.BufferName("unnamed")
 		e.buffers = append(e.buffers, buf)
 	}
 	e.redraw = make(chan struct{})
@@ -140,7 +140,7 @@ func (e *Editor) getBuffer(name string) *buffer.Buffer {
 }
 
 // BufferName generates a buffer name based on the one given.
-func (e *Editor) bufferName(name string) string {
+func (e *Editor) BufferName(name string) string {
 	if buf := e.getBuffer(name); buf == nil {
 		return name
 	}
@@ -181,7 +181,7 @@ func (e *Editor) NewBufferFromFile(filename string) (*buffer.Buffer, error) {
 	}
 	buf.Path = fullpath
 
-	buf.Name = e.bufferName(filename)
+	buf.Name = e.BufferName(filename)
 	e.buffers = append(e.buffers, buf)
 	return buf, nil
 }

--- a/mode/command.go
+++ b/mode/command.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kisielk/vigo/editor"
+	cmd "github.com/kisielk/vigo/commands"
 	"github.com/nsf/termbox-go"
 )
 
@@ -74,9 +75,9 @@ func execCommand(e *editor.Editor, command string) error {
 		return nil
 	}
 
-	cmd, args := fields[0], fields[1:]
+	command, args := fields[0], fields[1:]
 
-	switch cmd {
+	switch command{
 	case "q":
 		// TODO if more than one split, close active one only.
 		e.Quit()
@@ -84,9 +85,9 @@ func execCommand(e *editor.Editor, command string) error {
 		b := e.ActiveView().Buffer()
 		switch len(args) {
 		case 0:
-			b.Save()
+			e.Commands <- cmd.SaveBuffer{b, ""}
 		case 1:
-			b.SaveAs(args[0])
+			e.Commands <- cmd.SaveBuffer{b, args[0]}
 		default:
 			return fmt.Errorf("too many arguments to :w")
 		}
@@ -118,7 +119,7 @@ func execCommand(e *editor.Editor, command string) error {
 		e.ActiveView().ShowHighlights(true)
 	}
 
-	if lineNum, err := strconv.Atoi(cmd); err == nil {
+	if lineNum, err := strconv.Atoi(command); err == nil {
 		// cmd is a number, we should move to that line
 		e.ActiveView().MoveCursorToLine(lineNum)
 	}

--- a/view/view.go
+++ b/view/view.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"unicode/utf8"
 	"text/template"
+	"unicode/utf8"
 
 	"github.com/kisielk/vigo/buffer"
 	"github.com/kisielk/vigo/utils"
@@ -15,7 +15,7 @@ import (
 
 type dirtyFlag int
 
-const VIEW_STATUS_TEMPLATE = `{{ if .Name }} {{ .Name }} {{ else }} (new file) {{ end }}{{ if not .Dirty }}[+]{{ end }} {{range .Messages}} {{ . }} {{ end }}( {{ .Row }}, {{ .Column }} )`
+const viewStatusTemplate = `{{ if .Name }} {{ .Name }} {{ else }} (new file) {{ end }}{{ if not .Dirty }}[+]{{ end }} {{range .Messages}} {{ . }} {{ end }}( {{ .Row }}, {{ .Column }} )`
 
 const (
 	VerticalThreshold   = 5
@@ -32,7 +32,6 @@ const (
 	// diretyEverything indicates that everything needs to be updated
 	dirtyEverything = dirtyContents | dirtyStatus
 )
-
 
 // viewLocation represents a view's position in the buffer. It needs to be
 // separated from the view, because it's also being saved by the buffer (in case
@@ -222,17 +221,17 @@ type Context struct {
 
 type StatusFunc func(args ...interface{})
 
-func (v *View) setViewStatus (args ...interface{}) {
+func (v *View) setViewStatus(args ...interface{}) {
 	v.statusBuf.Reset()
 	data := struct {
-		Name string
-		Dirty bool
-		Row int
-		Column int
+		Name     string
+		Dirty    bool
+		Row      int
+		Column   int
 		Messages []interface{}
-	} {
+	}{
 		v.buf.Name,
-		v.ViewDirty(),
+		v.IsDirty(),
 		v.cursor.LineNum,
 		v.cursorVoffset,
 		args}
@@ -284,7 +283,7 @@ func NewView(ctx Context, buf *buffer.Buffer, redraw chan struct{}) *View {
 		tags:            make([]Tag, 0, 10),
 		redraw:          redraw,
 		showHighlights:  true,
-		StatusTemplate:  *template.Must(template.New("viewstatus").Parse(VIEW_STATUS_TEMPLATE)),
+		StatusTemplate:  *template.Must(template.New("viewstatus").Parse(viewStatusTemplate)),
 	}
 	v.Attach(buf)
 	return v
@@ -661,8 +660,8 @@ func (v *View) adjustCursorLine() {
 	}
 }
 
-// ViewDirty returns true if the buffer contents of this view has changed
-func (v *View) ViewDirty() bool {
+// IsDirty returns true if the buffer contents of this view has changed
+func (v *View) IsDirty() bool {
 	return v.buf.SyncedWithDisk()
 }
 

--- a/view/view.go
+++ b/view/view.go
@@ -15,7 +15,7 @@ import (
 
 type dirtyFlag int
 
-const VIEW_STATUS_TEMPLATE = `{{ if .Name }} {{ .Name }} {{ else }} (new file) {{ end }}{{ if .Dirty }} [*] {{ end }}{{range .Messages}} {{ . }} {{ else }} | {{ end }}( {{ .Row }}, {{ .Column }} )`
+const VIEW_STATUS_TEMPLATE = `{{ if .Name }} {{ .Name }} {{ else }} (new file) {{ end }}{{ if not .Dirty }}[+]{{ end }} {{range .Messages}} {{ . }} {{ end }}( {{ .Row }}, {{ .Column }} )`
 
 const (
 	VerticalThreshold   = 5
@@ -551,6 +551,7 @@ func (v *View) drawStatus() {
 	lp := tulib.DefaultLabelParams
 	lp.Bg = termbox.AttrReverse
 	lp.Fg = termbox.AttrReverse | termbox.AttrBold
+
 	v.uiBuf.Fill(
 		tulib.Rect{X: 0, Y: v.height(), Width: v.uiBuf.Width, Height: 1},
 		termbox.Cell{Fg: termbox.AttrReverse, Bg: termbox.AttrReverse, Ch: '─'},
@@ -559,11 +560,9 @@ func (v *View) drawStatus() {
 	// Update Status
 	v.setViewStatus()
 
-	// filename
-	namel := v.statusBuf.Len()
 	lp.Fg = termbox.AttrReverse
-	
-	v.uiBuf.DrawLabel(tulib.Rect{X: 5 + namel, Y: v.height(), Width: v.uiBuf.Width, Height: 1}, &lp, v.statusBuf.Bytes())
+	v.uiBuf.DrawLabel(tulib.Rect{X: 5, Y: v.height(), Width: v.uiBuf.Width, Height: 1}, &lp, v.statusBuf.Bytes())
+
 	v.statusBuf.Reset()
 }
 
@@ -664,7 +663,7 @@ func (v *View) adjustCursorLine() {
 
 // ViewDirty returns true if the buffer contents of this view has changed
 func (v *View) ViewDirty() bool {
-	return dirtyContents == (v.dirty & dirtyContents)
+	return v.buf.SyncedWithDisk()
 }
 
 // When 'cursor_line' was changed, call this function to possibly adjust the


### PR DESCRIPTION
- update the status, Name and Path on a buffer you Save as (currently,
  it will change you to the new file if you save to a new file.  this
  will be shown in the status)
- Kinda borked the dirty flag display - so that needs to be fixed.
- need to refactor the reused code on Editor, view and context.
- Dynamically load template strings?

this is for issue #42

_Not ready yet - Comments wanted_
